### PR TITLE
Fix atom and rss2 URLs (and PHP deprecated warning)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -49,7 +49,7 @@ function feed_url_template( $feed, $echo = true ) {
 		return new WP_Error( 'unsupported_feed_type' );
 	}
 
-	$feed_url_template = add_query_arg( 's', 'searchTerms', bloginfo( "{$feed}_url" ) );
+	$feed_url_template = add_query_arg( 's', 'searchTerms', get_bloginfo( "{$feed}_url" ) );
 
 	/**
 	 * Filters the Search-URL-Template


### PR DESCRIPTION
Closes https://wordpress.org/support/topic/php-deprecated-preg_replace-passing-null-to-parameter-2/